### PR TITLE
Fix cross-browser inputs issues

### DIFF
--- a/src/02-molecules/inputs.css
+++ b/src/02-molecules/inputs.css
@@ -14,7 +14,8 @@
     box-sizing: border-box;
     color: $color-neutral-900;
     height: 3rem;
-    padding: 0 $spacing-md;
+    /* Placeholder text won't vertically align middle on Firefox so have to go with this weird top/bottom padding */
+    padding: 12px $spacing-md;
     text-align: left;
     width: 324px;
 }


### PR DESCRIPTION
**Resolves issue #32**

**Implementation Summary**

- Fixed placeholder alignments on Firefox

**Comments (if any)**

The tabbing issues on Safari are related to a default setting in Safari which [disables normal tab behaviour](https://stackoverflow.com/questions/1848390/safari-ignoring-tabindex).
